### PR TITLE
Add sync operation to datomic client memdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datomic Client protocols for Datomic Peer databases.
 
 Add to your project.clj:
 ```clojure
-[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha2"]
+[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha3"]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datomic Client protocols for Datomic Peer databases.
 
 Add to your project.clj:
 ```clojure
-[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha3"]
+[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha4"]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datomic Client protocols for Datomic Peer databases.
 
 Add to your project.clj:
 ```clojure
-[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha1"]
+[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha2"]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datomic Client protocols for Datomic Peer databases.
 
 Add to your project.clj:
 ```clojure
-[com.nedap.staffing-solutions/datomic-client-memdb "0.3.0"]
+[com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha1"]
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha1"
+(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha2"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.datomic/client "0.8.69"]
                  [com.datomic/datomic-free "0.9.5697"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha2"
+(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha3"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.datomic/client "0.8.69"]
                  [com.datomic/datomic-free "0.9.5697"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha3"
+(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha4"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.datomic/client "0.8.69"]
                  [com.datomic/datomic-free "0.9.5697"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.3.0"
+(defproject com.nedap.staffing-solutions/datomic-client-memdb "0.4.0-alpha1"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.datomic/client "0.8.69"]
                  [com.datomic/datomic-free "0.9.5697"]]

--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -81,7 +81,7 @@
         (update-vals #{:db-before :db-after} #(LocalDb. % db-name))))
 
   (sync [_ t]
-    @(peer/sync conn t))
+    (LocalDb. @(peer/sync conn t) db-name))
 
   (tx-range [_ arg-map]
     (peer/tx-range (peer/log conn) (:start arg-map) (:end arg-map)))

--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -86,6 +86,9 @@
   (with-db [this]
     (client/db this))
 
+  (sync [this t]
+    (peer/sync this t))
+
   clojure.lang.ILookup
   (valAt [this k]
     (.valAt this k nil))

--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -80,14 +80,14 @@
     (-> @(peer/transact conn (:tx-data arg-map))
         (update-vals #{:db-before :db-after} #(LocalDb. % db-name))))
 
+  (sync [this t]
+    (peer/sync conn t))
+
   (tx-range [_ arg-map]
     (peer/tx-range (peer/log conn) (:start arg-map) (:end arg-map)))
 
   (with-db [this]
     (client/db this))
-
-  (sync [this t]
-    (peer/sync this t))
 
   clojure.lang.ILookup
   (valAt [this k]

--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -80,8 +80,8 @@
     (-> @(peer/transact conn (:tx-data arg-map))
         (update-vals #{:db-before :db-after} #(LocalDb. % db-name))))
 
-  (sync [this t]
-    (peer/sync conn t))
+  (sync [_ t]
+    @(peer/sync conn t))
 
   (tx-range [_ arg-map]
     (peer/tx-range (peer/log conn) (:start arg-map) (:end arg-map)))


### PR DESCRIPTION
This change adds the `d/sync` operation to the implementation of the Connection protocol in this library. It just forwards it to whatever the underlying peer connection does when `d/sync`'ing.