### PR TITLE
Add :as-of, :since and :history to the keys supported by db values

### DIFF
--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -68,6 +68,9 @@
       :t (peer/basis-t db)
       :next-t (inc (:t this))
       :db-name db-name
+      :as-of (peer/as-of-t db)
+      :since (peer/since-t db)
+      :history (boolean (or (peer/as-of-t db) (peer/since-t db)))
       not-found)))
 
 


### PR DESCRIPTION
A database value in datomic has five (supported) keys you can index on it: `:t`, `:as-of`, `:since`, `:db-name` and `:history`, this lib only supported some.

I got surprised that database values that are 'as of', don't have the as of timepoint in `:t`, but instead `:t` points to the newest t that this database value can reach. So to determine what timepoint the db is for actually, say because you are using it in a cache key, you need to take `:as-of` and `:since` into account.